### PR TITLE
Support overriding the default Docker

### DIFF
--- a/scratch.go
+++ b/scratch.go
@@ -421,6 +421,21 @@ func prepare(config *Config, docker string, args ...string) error {
 		return err
 	}
 
+	if err := setupBin(config, docker); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func setupBin(config *Config, docker string) error {
+	if _, err := os.Stat(docker); os.IsNotExist(err) {
+		dist := docker + ".dist"
+		if _, err := os.Stat(dist); err == nil {
+			return os.Symlink(dist, docker)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
If you run `dockerlaunch /usr/bin/docker` it will look for a file
named `/usr/bin/docker.dist` and then it will symlink it to
`/usr/bin/docker` if it does not exist.  This allows RancherOS to
package a default Docker that can be overridden.
