### PR TITLE
Update the usage example message

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY build/dockerlaunch /usr/bin/
 COPY build/docker /usr/bin/docker
 VOLUME /var/lib/docker
 ENTRYPOINT ["/usr/bin/dockerlaunch", "/usr/bin/docker"]
-CMD ["-d", "-s", "overlay"]
+CMD ["daemon", "-s", "overlay"]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker exec -it daemon docker ps
 
 ```bash
 # Daemon
-docker run --name daemon --privileged -d rancher/docker -d -s aufs
+docker run --name daemon --privileged -d rancher/docker daemon -s aufs
 
 # Client
 docker exec -it daemon docker ps
@@ -37,7 +37,7 @@ FROM ubuntu
 ADD files.tar /
 ENTRYPOINT ["/usr/bin/dockerlaunch", "/usr/bin/docker"]
 VOLUME /var/lib/docker
-CMD ["-d", "-s", "overlay"]
+CMD ["daemon", "-s", "overlay"]
 
 EOF
 

--- a/main/main.go
+++ b/main/main.go
@@ -17,7 +17,7 @@ func Main() {
 	}
 
 	if len(os.Args) < 2 {
-		log.Fatalf("Usage Example: %s /usr/bin/docker -d -D", os.Args[0])
+		log.Fatalf("Usage Example: %s /usr/bin/docker daemon -D", os.Args[0])
 	}
 
 	args := []string{}


### PR DESCRIPTION
Using dockerlaunch /usr/bin/docker -d -D will get the following
warning:
    Warning: '-d' is deprecated, it will be removed soon. See usage.
    WARN[0000] please use 'docker daemon' instead.

This patch just update the message for users.

Signed-off-by: Wang Long long.wanglong@huawei.com
