### PR TITLE
replace syscall.Dup2 with syscall.Dup3

### DIFF
--- a/scratch.go
+++ b/scratch.go
@@ -520,8 +520,8 @@ func setupLogging(config *Config) error {
 		return err
 	}
 
-	syscall.Dup2(int(output.Fd()), int(os.Stdout.Fd()))
-	syscall.Dup2(int(output.Fd()), int(os.Stderr.Fd()))
+	syscall.Dup3(int(output.Fd()), int(os.Stdout.Fd()), 0)
+	syscall.Dup3(int(output.Fd()), int(os.Stderr.Fd()), 0)
 
 	return nil
 }


### PR DESCRIPTION
because golang has no dup2 syscall in ARM64 architecture.
we should use dup3 which exists both in X86_64 and ARM64 architecture.

Signed-off-by: Wang Long long.wanglong@huawei.com
