### PR TITLE
Bump to go-1.6, base-image-0.4.0, docker-1.10.2 for builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,5 @@
 build:
-  image: rancher/dapper:1.9.1
+  image: rancher/dapper:1.10.2
   volumes:
   - /var/run/docker.sock:/var/run/docker.sock
   commands:

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,7 +1,7 @@
-FROM golang:1.5.3
+FROM golang:1.6
 
 RUN apt-get update && apt-get -y install libselinux-dev pkg-config
-RUN curl -o /usr/local/bin/docker -L https://get.docker.com/builds/Linux/x86_64/docker-1.9.1 && \
+RUN wget -O /usr/local/bin/docker -L https://get.docker.com/builds/Linux/x86_64/docker-1.10.2 && \
     chmod +x /usr/local/bin/docker
 
 ENV DAPPER_SOURCE /go/src/github.com/rancher/docker-from-scratch
@@ -18,21 +18,24 @@ WORKDIR ${DAPPER_SOURCE}
 RUN mkdir -p assets
 
 WORKDIR ${DAPPER_SOURCE}/assets
-RUN curl -OL https://github.com/rancher/docker-from-scratch/releases/download/bin-v0.3.1/base-files_amd64.tar.gz
-RUN curl -OL https://github.com/rancher/docker-from-scratch/releases/download/bin-v0.3.1/base-files_arm.tar.gz
+RUN wget https://github.com/rancher/docker-from-scratch/releases/download/bin-v0.4.0/base-files_amd64.tar.gz
+RUN wget https://github.com/rancher/docker-from-scratch/releases/download/bin-v0.4.0/base-files_arm.tar.gz
+RUN wget https://github.com/rancher/docker-from-scratch/releases/download/bin-v0.4.0/base-files_arm64.tar.gz
 
-RUN curl -o ./docker_amd64 -L https://get.docker.com/builds/Linux/x86_64/docker-1.10.2 && \
+RUN wget -O ./docker_amd64 -L https://get.docker.com/builds/Linux/x86_64/docker-1.10.2 && \
     chmod +x ./docker_amd64
-RUN curl -o ./docker_arm -L https://github.com/rancher/docker/releases/download/v1.10.2-ros_arm/docker-1.10.2 && \
+RUN wget -O ./docker_arm -L https://github.com/rancher/docker/releases/download/v1.10.2-arm2/docker-1.10.2_arm && \
     chmod +x ./docker_arm
+RUN wget -O ./docker_arm64 -L https://github.com/rancher/docker/releases/download/v1.10.2-arm2/docker-1.10.2_arm64 && \
+    chmod +x ./docker_arm64
 
 WORKDIR ${DAPPER_SOURCE}
 
 COPY ./scripts/crosstools.list /etc/apt/sources.list.d/
 
 RUN sh -c 'curl http://emdebian.org/tools/debian/emdebian-toolchain-archive.key | apt-key add -' && \
-    dpkg --add-architecture armhf && \
+    dpkg --add-architecture armhf && dpkg --add-architecture arm64 && \
     apt-get update && \
-    apt-get install -y crossbuild-essential-armhf
+    apt-get install -y crossbuild-essential-armhf crossbuild-essential-arm64
 
 CMD ./scripts/ci

--- a/scripts/build
+++ b/scripts/build
@@ -17,4 +17,9 @@ if [ "${arch}" == "arm" ]; then
   export CC=/usr/bin/arm-linux-gnueabihf-gcc
   export CGO_ENABLED=1
 fi
+if [ "${arch}" == "arm64" ]; then
+  export CC=/usr/bin/aarch64-linux-gnu-gcc
+  export CGO_ENABLED=1
+fi
+
 GOARCH=${arch} go build -ldflags "-linkmode external -extldflags -static" -o build/dockerlaunch ./main

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,7 +3,7 @@ set -e
 
 cd $(dirname $0)
 
-: ${ARCH:='amd64 arm'}
+: ${ARCH:='amd64 arm arm64'}
 
 for arch in ${ARCH}; do
     ./build ${arch}

--- a/selinux/selinux_arm64.go
+++ b/selinux/selinux_arm64.go
@@ -1,0 +1,6 @@
+package selinux
+
+// SetFileContext is a stub for SELinux support on ARM
+func SetFileContext(path string, context string) (int, error) {
+	return 0, nil
+}


### PR DESCRIPTION
Bump to go-1.6, base-image-0.4.0, docker-1.10.2 for builds

~~WIP until~~ #47 merged and base-image-0.4.0 is tagged
